### PR TITLE
Takeoff integration

### DIFF
--- a/libs/langchain/langchain/llms/__init__.py
+++ b/libs/langchain/langchain/llms/__init__.py
@@ -74,6 +74,7 @@ from langchain.llms.self_hosted import SelfHostedPipeline
 from langchain.llms.self_hosted_hugging_face import SelfHostedHuggingFaceLLM
 from langchain.llms.stochasticai import StochasticAI
 from langchain.llms.textgen import TextGen
+from langchain.llms.titan_takeoff import TitanTakeoff
 from langchain.llms.tongyi import Tongyi
 from langchain.llms.vertexai import VertexAI
 from langchain.llms.writer import Writer
@@ -137,6 +138,7 @@ __all__ = [
     "SelfHostedHuggingFaceLLM",
     "SelfHostedPipeline",
     "StochasticAI",
+    "TitanTakeoff",
     "Tongyi",
     "VertexAI",
     "Writer",
@@ -195,6 +197,7 @@ type_to_cls_dict: Dict[str, Type[BaseLLM]] = {
     "self_hosted_hugging_face": SelfHostedHuggingFaceLLM,
     "stochasticai": StochasticAI,
     "tongyi": Tongyi,
+    "titan_takeoff": TitanTakeoff,
     "vertexai": VertexAI,
     "openllm": OpenLLM,
     "openllm_client": OpenLLM,

--- a/libs/langchain/langchain/llms/titan_takeoff.py
+++ b/libs/langchain/langchain/llms/titan_takeoff.py
@@ -1,0 +1,55 @@
+import re
+from typing import Any, List, Mapping, Optional
+from langchain.llms.base import LLM
+from langchain.llms.utils import enforce_stop_tokens
+
+class TitanTakeoff(LLM):
+    port: int = 8000
+    """Specifies the port to use for the Titan Takeoff API. Default = 8000."""
+    generate_max_length: int = 128
+    sampling_topk: int = 1
+    sampling_topp: float = 1.0
+    sampling_temperature: float = 1.0
+    repetition_penalty: float = 1.0
+    no_repeat_ngram_size: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "titan_takeoff"
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]],
+    ) -> str:
+        import requests
+
+        url = f"http://localhost:{self.port}/generate"
+        json = {
+            "text": prompt,
+            "generate_max_length": self.generate_max_length,
+            "sampling_topk": self.sampling_topk,
+            "sampling_topp": self.sampling_topp,
+            "sampling_temperature": self.sampling_temperature,
+            "repetition_penalty": self.repetition_penalty,
+            "no_repeat_ngram_size": self.no_repeat_ngram_size,
+        }
+
+        response = requests.post(url, json=json)
+        response.encoding = 'utf-8'
+        text = ""
+
+        if "message" in response.json():
+            text = response.json()["message"]
+        else:
+            raise ValueError("Something went wrong.")
+        if stop is None:
+            text = enforce_stop_tokens(text, [re.escape('<|endoftext|>')])
+        else:
+            text = enforce_stop_tokens(text, stop)
+        return text
+
+    @property
+    def _identifying_params(self) -> Mapping[str, Any]:
+        """Get the identifying parameters."""
+        return {"port": self.port}

--- a/libs/langchain/langchain/llms/titan_takeoff.py
+++ b/libs/langchain/langchain/llms/titan_takeoff.py
@@ -1,7 +1,13 @@
 import re
-from typing import Any, List, Mapping, Optional
+from typing import Any, Iterator, List, Mapping, Optional
+
+import requests
+
+from langchain.callbacks.manager import CallbackManagerForLLMRun
 from langchain.llms.base import LLM
 from langchain.llms.utils import enforce_stop_tokens
+from langchain.schema.output import GenerationChunk
+
 
 class TitanTakeoff(LLM):
     port: int = 8000
@@ -12,6 +18,25 @@ class TitanTakeoff(LLM):
     sampling_temperature: float = 1.0
     repetition_penalty: float = 1.0
     no_repeat_ngram_size: int = 0
+    streaming: bool = False
+
+    @property
+    def _default_params(self) -> Mapping[str, Any]:
+        """Get the default parameters for calling Titan Takeoff Server."""
+        params = {}
+        if self.generate_max_length:
+            params["generate_max_length"] = self.generate_max_length
+        if self.sampling_topk:
+            params["sampling_topk"] = self.sampling_topk
+        if self.sampling_topp:
+            params["sampling_topp"] = self.sampling_topp
+        if self.sampling_temperature:
+            params["sampling_temperature"] = self.sampling_temperature
+        if self.repetition_penalty:
+            params["repetition_penalty"] = self.repetition_penalty
+        if self.no_repeat_ngram_size:
+            params["no_repeat_ngram_size"] = self.no_repeat_ngram_size
+        return params
 
     @property
     def _llm_type(self) -> str:
@@ -21,22 +46,23 @@ class TitanTakeoff(LLM):
         self,
         prompt: str,
         stop: Optional[List[str]],
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
     ) -> str:
-        import requests
+        if self.streaming:
+            text_output = ""
+            for chunk in self._stream(
+                prompt=prompt,
+                stop=stop,
+                run_manager=run_manager,
+            ):
+                text_output += chunk.text
+            return text_output
 
         url = f"http://localhost:{self.port}/generate"
-        json = {
-            "text": prompt,
-            "generate_max_length": self.generate_max_length,
-            "sampling_topk": self.sampling_topk,
-            "sampling_topp": self.sampling_topp,
-            "sampling_temperature": self.sampling_temperature,
-            "repetition_penalty": self.repetition_penalty,
-            "no_repeat_ngram_size": self.no_repeat_ngram_size,
-        }
+        params = {"text": prompt, **self._default_params}
 
-        response = requests.post(url, json=json)
-        response.encoding = 'utf-8'
+        response = requests.post(url, json=params)
+        response.encoding = "utf-8"
         text = ""
 
         if "message" in response.json():
@@ -44,12 +70,30 @@ class TitanTakeoff(LLM):
         else:
             raise ValueError("Something went wrong.")
         if stop is None:
-            text = enforce_stop_tokens(text, [re.escape('<|endoftext|>')])
+            text = enforce_stop_tokens(text, [re.escape("<|endoftext|>")])
         else:
             text = enforce_stop_tokens(text, stop)
         return text
 
+    def _stream(
+        self,
+        prompt: str,
+        stop: Optional[List[str]],
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+    ) -> Iterator[GenerationChunk]:
+        url = f"http://localhost:{self.port}/generate_stream"
+        params = {"text": prompt, **self._default_params}
+
+        response = requests.post(url, json=params, stream=True)
+        response.encoding = "utf-8"
+        for text in response.iter_content(chunk_size=1, decode_unicode=True):
+            if text:
+                chunk = GenerationChunk(text=text)
+                yield chunk
+                if run_manager:
+                    run_manager.on_llm_new_token(token=chunk.text)
+
     @property
     def _identifying_params(self) -> Mapping[str, Any]:
         """Get the identifying parameters."""
-        return {"port": self.port}
+        return {"port": self.port, **{}, **self._default_params}

--- a/libs/langchain/tests/integration_tests/llms/test_titan_takeoff.py
+++ b/libs/langchain/tests/integration_tests/llms/test_titan_takeoff.py
@@ -1,0 +1,17 @@
+"""Test Titan Takeoff wrapper."""
+
+from typing import Any, List, Optional
+from langchain.llms.titan_takeoff import TitanTakeoff
+import requests
+import responses
+
+@responses.activate
+def test_titan_takeoff_call() -> None:
+    """Test valid call to Titan Takeoff."""
+    url="http://localhost:8000/generate"
+    responses.add(responses.POST, url, json={"message": "2 + 2 is 4"}, status=200)
+
+    # response = requests.post(url)
+    llm = TitanTakeoff()
+    output = llm("What is 2 + 2?")
+    assert isinstance(output, str)


### PR DESCRIPTION
## Description:
This PR adds the Titan Takeoff Server to the available LLMs in LangChain.

Titan Takeoff is an inference server that allows you to deploy large language models locally on your hardware in a single command. Most generative model architectures are included, such as Falcon, Llama 2, GPT2, T5 and many more.

You can read more about Titan Takeoff here:
- [Blog](https://medium.com/@TitanML/introducing-titan-takeoff-6c30e55a8e1e)
- [Docs](https://docs.titanml.co/docs/titan-takeoff/getting-started)

#### Testing
As Titan Takeoff runs locally on port 8000 by default, no network access is needed. Responses are mocked for testing.

[ ] Make Lint
[ ] Make Format
[ ] Make Test

#### Dependencies
No new dependencies are introduced. However, users will need to install the titan-iris package in their local environment and start the Titan Takeoff inferencing server in order to use the TitanTakeoff integration.
